### PR TITLE
Add several european regions to azure grid emissions factors file

### DIFF
--- a/data/grid-emissions-factors-azure.csv
+++ b/data/grid-emissions-factors-azure.csv
@@ -18,3 +18,8 @@ South India,Chennai,,0.000708,carbonfootprint.com
 West India,Mumbai,,0.000708,carbonfootprint.com
 UK South,London,,0.000228,EEA
 UK West,Cardiff,,0.000228,EEA
+France Central,Paris,,0.000067,EEA
+Finland Central,Helsinki,,000077,EEA,
+Germany West Central,Frankfurt,,000402,EEA
+Belgium Central,Brussels,,0.000154,EEA
+Sweden Central,Gavle,,0.000009,EEA


### PR DESCRIPTION
Hi!

I work at Easyvirt, a French company that works on optimization of on-premise VMware infrastructures.
We really love what CloudCarbonFootprint have done, and it helped us to estimate the carbon emissions footprint of migrating on-premise datacenters in public clouds. As most of our customers are located in Europe, we have extended the coefficients to includes cloud regions located in Europe.

In this pull request, we propose some modifications we made to the `grid-emissions-factors-azure.csv` file : it is extended with several European regions.

We don't know if you are interested in such contributions, or if it is the right way to contribute. Please tell me if there is a better way to contribute.

Best regards,

Jonathan Pastor